### PR TITLE
fix: puml syntax error

### DIFF
--- a/docs/flows/flows.puml
+++ b/docs/flows/flows.puml
@@ -181,7 +181,7 @@ bitdaoadmin <-- snapshot: pass/fail
 bitdaoadmin -> insurancecontract: if (pass) terminate insurance
 bitdaoadmin <-- insurancecontract: execute proposal
 
-new page
+newpage
 
 autonumber "Upgrades:[00]"
 


### PR DESCRIPTION
Syntax error prevents the WebStorm plugin from rendering the PUML doc.