### PR TITLE
ci: code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,15 @@
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo, unless a later match takes precedence.
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only the *.js file owner of review is requested
+
+
+# Global code owner (WindRanger core team)
+*           @windranger-io/windranger-core
+
+# GitHub Actions owners
+/.github/   @windranger-io/windranger-core

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,4 +12,4 @@
 *           @windranger-io/windranger-core
 
 # GitHub Actions owners
-/.github/   @windranger-io/windranger-core
+/.github/   @windranger-io/windranger-devops


### PR DESCRIPTION
Adding code owners (which are in used in conjunction with the branch protection settings), from which at least one approval is required.