### PR TITLE
feat: replacing dependabot with renovate

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "monthly"
+

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,11 @@
+{
+  "extends": ["config:base", "group:all", "schedule:monthly"],
+  "assigneesFromCodeOwners": true,
+  "assigneesSampleSize": 1,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["pin", "digest", "lockFileMaintenance"],
+      "enabled": false
+    }
+  ]
+}


### PR DESCRIPTION
### Purpose for this PR
Renovate has now been activated by default for all repos.

The selling point of Renovate is all the dependencies in a single PR, rather than the Dependabot one PR per an update.

Unfortunately security updates are still raised single PRs
<!-- Have you included adequate testing for this change? -->